### PR TITLE
Fix ACarouselViewModel.itemWidth returning negative value

### DIFF
--- a/Sources/ACarousel/ACarouselViewModel.swift
+++ b/Sources/ACarousel/ACarouselViewModel.swift
@@ -140,7 +140,7 @@ extension ACarouselViewModel {
     }
     
     var itemWidth: CGFloat {
-        viewSize.width - defaultPadding * 2
+        max(0, viewSize.width - defaultPadding * 2)
     }
     
     var timer: TimePublisher? {


### PR DESCRIPTION
Upon showing a View which contains ACarousel, 2 identical runtime warnings are produced in debug console. Both are pointing on [this line](https://github.com/JWAutumn/ACarousel/blob/8a322513580f21288fd87eb3a1341c247b3e2a76/Sources/ACarousel/ACarousel.swift#L42). Adding a print statement (debugger in runtime was not that helpful) in `ACarouselViewModel.itemWidth` revealed the following:
```
0.0 - 30.0 * 2 -> -60.0
0.0 - 30.0 * 2 -> -60.0
2021-06-10 20:21:41.108133+0200 app[43860:8134542] [SwiftUI] Invalid frame dimension (negative or non-finite).
0.0 - 30.0 * 2 -> -60.0
2021-06-10 20:21:41.111586+0200 app[43860:8134542] [SwiftUI] Invalid frame dimension (negative or non-finite).
375.0 - 30.0 * 2 -> 315.0
375.0 - 30.0 * 2 -> 315.0
375.0 - 30.0 * 2 -> 315.0
375.0 - 30.0 * 2 -> 315.0
375.0 - 30.0 * 2 -> 315.0
375.0 - 30.0 * 2 -> 315.0
```